### PR TITLE
Let CMAKE_PREFIX_PATH control the install dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,6 @@ target_link_libraries(${PROJECT_NAME}   ${Boost_LIBRARIES}
 )
 
 # install
-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${PROJECT_SOURCE_DIR}/bin
-                                LIBRARY DESTINATION ${PROJECT_SOURCE_DIR}/lib
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin
+                                LIBRARY DESTINATION lib
 )


### PR DESCRIPTION
I had some problems using cvmatio within another project (specifically because the install is hard-coded to `PROJECT_SOURCE_DIR`). It's usually the responsibility of whoever is building it to set `CMAKE_PREFIX_PATH` to their chosen install dir.
