### PR TITLE
use const and references whenever possible

### DIFF
--- a/include/EFStream.hpp
+++ b/include/EFStream.hpp
@@ -56,7 +56,7 @@ public:
     EFStream() : byte_swap_(false) {}
 
     // get and set byte swap methods
-    bool byteSwap(void) { return byte_swap_; }
+    bool byteSwap(void) const { return byte_swap_; }
     void setByteSwap(bool state) { byte_swap_ = state; }
 
     // method to swap the Endianness of a stream

--- a/include/MatlabIO.hpp
+++ b/include/MatlabIO.hpp
@@ -77,38 +77,38 @@ private:
     bool byte_swap_;
     int bytes_read_;
     std::string filename_;
-    EFStream fid_;
+    mutable EFStream fid_;
     // internal methods
     void getHeader(void);
     void setHeader(void);
     bool hasVariable(void) { return fid_.peek() != EOF; }
-	template<class T> MatlabIOContainer constructMatrix(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real, std::vector<char>& imag, uint32_t stor_type);
-	MatlabIOContainer constructString(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real);
-	MatlabIOContainer constructSparse(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real, std::vector<char>& imag);
-	MatlabIOContainer constructCell(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real);
-	MatlabIOContainer constructStruct(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real);
-	const char *      readVariableTag(uint32_t &data_type, uint32_t &dbytes, uint32_t &wbytes, const char *data);
-	MatlabIOContainer collateMatrixFields(uint32_t data_type, uint32_t nbytes, std::vector<char> data);
-	std::vector<char> uncompressVariable(uint32_t& data_type, uint32_t& dbytes, uint32_t& wbytes, const std::vector<char> &data);
-    MatlabIOContainer readVariable(uint32_t data_type, uint32_t nbytes, const std::vector<char> &data);
-    MatlabIOContainer readBlock(void);
-    MatlabIOContainer uncompressFromBin(std::vector<char> data, uint32_t nbytes);
+	template<class T> MatlabIOContainer constructMatrix(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real, std::vector<char>& imag, uint32_t stor_type) const;
+	MatlabIOContainer constructString(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real) const;
+	MatlabIOContainer constructSparse(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real, std::vector<char>& imag) const;
+	MatlabIOContainer constructCell(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real) const;
+	MatlabIOContainer constructStruct(std::vector<char>& name, std::vector<uint32_t>& dims, std::vector<char>& real) const;
+	const char *      readVariableTag(uint32_t &data_type, uint32_t &dbytes, uint32_t &wbytes, const char *data) const;
+	MatlabIOContainer collateMatrixFields(uint32_t data_type, uint32_t nbytes, const std::vector<char>& data) const;
+	std::vector<char> uncompressVariable(uint32_t& data_type, uint32_t& dbytes, uint32_t& wbytes, const std::vector<char> &data) const;
+    MatlabIOContainer readVariable(uint32_t data_type, uint32_t nbytes, const std::vector<char> &data) const;
+    MatlabIOContainer readBlock(void) const;
+    MatlabIOContainer uncompressFromBin(std::vector<char> data, uint32_t nbytes) const;
 public:
     // constructors
     MatlabIO() {}
     // destructor
     ~MatlabIO() { close(); }
     // get and set methods
-    std::string filename(void) { return std::string(filename_); }
+    const std::string& filename(void) const { return filename_; }
     // read and write routines
-    bool open(std::string filename, std::string mode);
+    bool open(const std::string& filename, const std::string& mode);
     bool close(void);
     std::vector<MatlabIOContainer> read(void);
-    void whos(std::vector<MatlabIOContainer> variables) const;
+    void whos(const std::vector<MatlabIOContainer>& variables) const;
 
     // templated functions (must be declared and defined in the header file)
     template<class T>
-    T find(std::vector<MatlabIOContainer>& variables, std::string name) const {
+    T find(const std::vector<MatlabIOContainer>& variables, const std::string& name) const {
     	for (unsigned int n = 0; n < variables.size(); ++n) {
     		if (variables[n].name().compare(name) == 0) {
     			if (isPrimitiveType<T>()) {
@@ -121,7 +121,7 @@ public:
     	throw new std::exception();
     }
 
-    MatlabIOContainer find(std::vector<MatlabIOContainer>& variables, std::string name) const {
+    MatlabIOContainer find(const std::vector<MatlabIOContainer>& variables, const std::string name) const {
     	for (unsigned int n = 0; n < variables.size(); ++n) {
     		if (variables[n].name().compare(name) == 0) return variables[n];
     	}
@@ -129,7 +129,7 @@ public:
     }
 
     template<class T>
-    bool typeEquals(std::vector<MatlabIOContainer>& variables, std::string name) const {
+    bool typeEquals(const std::vector<MatlabIOContainer>& variables, const std::string name) const {
     	for (unsigned int n = 0; n < variables.size(); ++n) {
     		if (variables[n].name().compare(name) == 0) return variables[n].typeEquals<T>();
     	}

--- a/include/MatlabIO.hpp
+++ b/include/MatlabIO.hpp
@@ -121,7 +121,7 @@ public:
     	throw new std::exception();
     }
 
-    MatlabIOContainer find(const std::vector<MatlabIOContainer>& variables, const std::string name) const {
+    MatlabIOContainer find(const std::vector<MatlabIOContainer>& variables, const std::string& name) const {
     	for (unsigned int n = 0; n < variables.size(); ++n) {
     		if (variables[n].name().compare(name) == 0) return variables[n];
     	}
@@ -129,7 +129,7 @@ public:
     }
 
     template<class T>
-    bool typeEquals(const std::vector<MatlabIOContainer>& variables, const std::string name) const {
+    bool typeEquals(const std::vector<MatlabIOContainer>& variables, const std::string& name) const {
     	for (unsigned int n = 0; n < variables.size(); ++n) {
     		if (variables[n].name().compare(name) == 0) return variables[n].typeEquals<T>();
     	}

--- a/include/MatlabIOContainer.hpp
+++ b/include/MatlabIOContainer.hpp
@@ -64,12 +64,12 @@ public:
      * @param name the string name of the variable
      * @param data the associated data, of any type
      */
-    MatlabIOContainer(const std::string name, const boost::any data) : name_(name), data_(data) {}
+    MatlabIOContainer(const std::string& name, const boost::any data) : name_(name), data_(data) {}
     // destructor
     ~MatlabIOContainer() {}
     // set methods
-    void setName(const std::string name) { name_ = name; }
-    void setData(const boost::any data) { data_ = data; }
+    void setName(const std::string& name) { name_ = name; }
+    void setData(const boost::any& data) { data_ = data; }
     // get methods
     /*! @brief Check if the stored type is equal to the templated type
      *
@@ -102,7 +102,7 @@ public:
 		if (tp == typeid(void)) return TypeName<void>::toString();
 		return std::string(tp.name());
 	}
-    std::string name(void) const { return name_; }
+    const std::string& name(void) const { return name_; }
     /*! @brief The stored data
      *
      * Returns the stored data, cast to the templated type

--- a/src/MatlabIO.cpp
+++ b/src/MatlabIO.cpp
@@ -51,7 +51,7 @@ using namespace cv;
  * @param mode either "r" for reading or "w" for writing
  * @return true if the file open succeeded, false otherwise
  */
-bool MatlabIO::open(string filename, string mode) {
+bool MatlabIO::open(const string& filename, const string& mode) {
 
     // open the file
 	filename_ = filename;
@@ -181,7 +181,7 @@ void MatlabIO::getHeader(void) {
  * @param data the input binary blob
  * @return a pointer to the beginning of the data segment of the binary blob
  */
-const char * MatlabIO::readVariableTag(uint32_t &data_type, uint32_t &dbytes, uint32_t &wbytes, const char *data) {
+const char * MatlabIO::readVariableTag(uint32_t &data_type, uint32_t &dbytes, uint32_t &wbytes, const char *data) const {
     
 	bool small = false;
     const uint32_t *datai = reinterpret_cast<const uint32_t *>(data);
@@ -214,7 +214,7 @@ const char * MatlabIO::readVariableTag(uint32_t &data_type, uint32_t &dbytes, ui
  * @param real
  * @return
  */
-MatlabIOContainer MatlabIO::constructStruct(vector<char>& name, vector<uint32_t>& dims, vector<char>& real) {
+MatlabIOContainer MatlabIO::constructStruct(vector<char>& name, vector<uint32_t>& dims, vector<char>& real) const {
 
 	vector<vector<MatlabIOContainer> > array;
 	const char* real_ptr = &(real[0]);
@@ -275,7 +275,7 @@ MatlabIOContainer MatlabIO::constructStruct(vector<char>& name, vector<uint32_t>
  * @param real the real part
  * @return the wrapped cell array
  */
-MatlabIOContainer MatlabIO::constructCell(vector<char>& name, vector<uint32_t>& dims, vector<char>& real) {
+MatlabIOContainer MatlabIO::constructCell(vector<char>& name, vector<uint32_t>& dims, vector<char>& real) const {
 
 	vector<MatlabIOContainer> cell;
 	char* field_ptr = &(real[0]);
@@ -303,7 +303,7 @@ MatlabIOContainer MatlabIO::constructCell(vector<char>& name, vector<uint32_t>& 
  * @param imag
  * @return
  */
-MatlabIOContainer MatlabIO::constructSparse(vector<char>&, vector<uint32_t>&, vector<char>&, vector<char>&) {
+MatlabIOContainer MatlabIO::constructSparse(vector<char>&, vector<uint32_t>&, vector<char>&, vector<char>&) const {
 
 	MatlabIOContainer variable;
 	return variable;
@@ -319,7 +319,7 @@ MatlabIOContainer MatlabIO::constructSparse(vector<char>&, vector<uint32_t>&, ve
  * @param real the string data
  * @return the wrapped string
  */
-MatlabIOContainer MatlabIO::constructString(vector<char>& name, vector<uint32_t>&, vector<char>& real) {
+MatlabIOContainer MatlabIO::constructString(vector<char>& name, vector<uint32_t>&, vector<char>& real) const {
 	// make sure the data is null terminated
 	real.push_back('\0');
 	return MatlabIOContainer(string(&(name[0])), string(&(real[0])));
@@ -345,7 +345,7 @@ MatlabIOContainer MatlabIO::constructString(vector<char>& name, vector<uint32_t>
  * @return the wrapped matrix
  */
 template<class T>
-MatlabIOContainer MatlabIO::constructMatrix(vector<char>& name, vector<uint32_t>& dims, vector<char>& real, vector<char>& imag, uint32_t stor_type) {
+MatlabIOContainer MatlabIO::constructMatrix(vector<char>& name, vector<uint32_t>& dims, vector<char>& real, vector<char>& imag, uint32_t stor_type) const {
 
 	vector<T> vec_real;
 	vector<T> vec_imag;
@@ -449,7 +449,7 @@ MatlabIOContainer MatlabIO::constructMatrix(vector<char>& name, vector<uint32_t>
  *
  * @return the variable (matrix, struct, cell, scalar) wrapped in a container
  */
-MatlabIOContainer MatlabIO::collateMatrixFields(uint32_t, uint32_t, vector<char> data) {
+MatlabIOContainer MatlabIO::collateMatrixFields(uint32_t, uint32_t, const vector<char>& data) const {
 
     // get the flags
     bool complx  = data[9] & (1 << 3);
@@ -548,7 +548,7 @@ MatlabIOContainer MatlabIO::collateMatrixFields(uint32_t, uint32_t, vector<char>
  * @param data the binary blob
  * @return the binary blob, uncompressed
  */
-vector<char> MatlabIO::uncompressVariable(uint32_t& data_type, uint32_t& dbytes, uint32_t& wbytes, const vector<char> &data) {
+vector<char> MatlabIO::uncompressVariable(uint32_t& data_type, uint32_t& dbytes, uint32_t& wbytes, const vector<char> &data) const {
     // setup the inflation parameters
     char buf[8];
     z_stream infstream;
@@ -593,7 +593,7 @@ vector<char> MatlabIO::uncompressVariable(uint32_t& data_type, uint32_t& dbytes,
  * @param data the binary blob
  * @return an interpreted variable
  */
-MatlabIOContainer MatlabIO::readVariable(uint32_t data_type, uint32_t nbytes, const vector<char> &data) {
+MatlabIOContainer MatlabIO::readVariable(uint32_t data_type, uint32_t nbytes, const vector<char> &data) const {
 
     // interpret the data
     MatlabIOContainer variable;
@@ -644,7 +644,7 @@ MatlabIOContainer MatlabIO::readVariable(uint32_t data_type, uint32_t nbytes, co
  *
  * @return the block of data interpreted as a variable and stored in a generic container
  */
-MatlabIOContainer MatlabIO::readBlock(void) {
+MatlabIOContainer MatlabIO::readBlock(void) const {
 
     // allocate the output
     MatlabIOContainer variable;
@@ -716,7 +716,7 @@ std::vector<MatlabIOContainer> MatlabIO::read(void) {
  * a list of variables and their C++ datatypes stored in the associated .Mat file
  * @param variables the variables read from the .Mat file using the read() function
  */
-void MatlabIO::whos(vector<MatlabIOContainer> variables) const {
+void MatlabIO::whos(const vector<MatlabIOContainer>& variables) const {
 
 	// get the longest filename
 	unsigned int flmax = 0;


### PR DESCRIPTION
this avoids copies when passing arguments to functions or when returning values from functions.
Also whenever possible const functions are now used.